### PR TITLE
Add a basic CI pipeline to build the dependencies to wasm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,34 +1,27 @@
 name: CI
-
-on:
+'on':
   create:
-    tags:
+    tags: null
   push:
     branches:
       - gh-action
-
-
 jobs:
   build:
-    name: Compile RGBDS and binjgb to wasm
+    name: WASM Build
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository and submodules
-      uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Setup emscripten
-      uses: mymindstorm/setup-emsdk@v11
-      with:
-        # Make sure to set a version number!
-        version: 3.1.45
-        # This is the name of the cache folder.
-        # The cache folder will be placed in the build directory,
-        #  so make sure it doesn't conflict with anything!
-        actions-cache-folder: 'emsdk-cache'
-    - name: Build RGBDS
-      run: ./build-rgbds.sh
-      shell: bash
-    - name: Build binjgb
-      run: ./build-binjgb.sh
-      shell: bash
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Setup emscripten
+        uses: mymindstorm/setup-emsdk@v11
+        with:
+          version: 3.1.45
+          actions-cache-folder: emsdk-cache
+      - name: Build RGBDS
+        run: ./build-rgbds.sh
+        shell: bash
+      - name: Build binjgb
+        run: ./build-binjgb.sh
+        shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,14 +10,14 @@ on:
 
 jobs:
   build:
-    name: build
+    name: Compile RGBDS and binjgb to wasm
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository and submodules
       uses: actions/checkout@v2
       with:
         submodules: recursive
-    - name: Setup emsdk
+    - name: Setup emscripten
       uses: mymindstorm/setup-emsdk@v11
       with:
         # Make sure to set a version number!
@@ -26,6 +26,9 @@ jobs:
         # The cache folder will be placed in the build directory,
         #  so make sure it doesn't conflict with anything!
         actions-cache-folder: 'emsdk-cache'
-    - name: build rgbds
+    - name: Build RGBDS
       run: ./build-rgbds.sh
+      shell: bash
+    - name: Build binjgb
+      run: ./build-binjgb.sh
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build:
     name: build
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout repository and submodules
       uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  create:
+    tags:
+  push:
+    branches:
+      - gh-action
+
+
+jobs:
+  build:
+    name: build
+    steps:
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Setup emscripten
+      uses: lovasoa/setup-emscripten@master
+      with:
+        emscripten-version: '1.38.47'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,12 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: recursive
-    - name: Setup emscripten
-      uses: lovasoa/setup-emscripten@master
+    - name: Setup emsdk
+      uses: mymindstorm/setup-emsdk@v11
       with:
-        emscripten-version: '1.38.47'
+        # Make sure to set a version number!
+        version: 1.38.40
+        # This is the name of the cache folder.
+        # The cache folder will be placed in the build directory,
+        #  so make sure it doesn't conflict with anything!
+        actions-cache-folder: 'emsdk-cache'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,4 +28,4 @@ jobs:
         actions-cache-folder: 'emsdk-cache'
     - name: build rgbds
       run: ./build-rgbds.sh
-        shell: bash
+      shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,11 @@ jobs:
       uses: mymindstorm/setup-emsdk@v11
       with:
         # Make sure to set a version number!
-        version: 1.38.40
+        version: 3.1.45
         # This is the name of the cache folder.
         # The cache folder will be placed in the build directory,
         #  so make sure it doesn't conflict with anything!
         actions-cache-folder: 'emsdk-cache'
+    - name: build rgbds
+      run: ./build-rgbds.sh
+        shell: bash

--- a/build-rgbds.sh
+++ b/build-rgbds.sh
@@ -11,8 +11,7 @@ cd rgbds
 
 patch -p1 < ../rgbds.patch
 echo "Allowing patching"
-read
-git diff > ../rgbds.patch
+
 
 MAKE_ARGS="Q= PNGCFLAGS= PNGLDFLAGS= PNGLDLIBS="
 CFLAGS="-O3 -s MODULARIZE=1 -s EXPORTED_RUNTIME_METHODS=['FS'] -s USE_LIBPNG"


### PR DESCRIPTION
- Install deps for compiling RGBDS
- Install deps for compiling binjgb
- Install emscripten (and cache it)

Closes https://github.com/gbdev/rgbds-live/issues/13