### PR TITLE
Automate changing link to documentation using git tag from RGBDS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,10 @@ set -eu
 
 test -d binjgb/out || ./build-binjgb.sh
 test -f rgbds/rgbasm.wasm || ./build-rgbds.sh
+
+#store rgbds version tag for use in vite build
+export VITE_RGBDS_VERSION=$(git --git-dir=rgbds/.git -c safe.directory='*' describe --tags --always)
+
 npm ci
 npm run build
 

--- a/build.sh
+++ b/build.sh
@@ -4,10 +4,6 @@ set -eu
 
 test -d binjgb/out || ./build-binjgb.sh
 test -f rgbds/rgbasm.wasm || ./build-rgbds.sh
-
-#store rgbds version tag for use in vite build
-export VITE_RGBDS_VERSION=$(git --git-dir=rgbds/.git -c safe.directory='*' describe --tags --always)
-
 npm ci
 npm run build
 

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
             <ul>
               <li id="infomenu">Info...</li>
               <li>
-                <a href="https://rgbds.gbdev.io/docs/v0.9.1" target="_blank">rgbds manual</a>
+                <a href="https://rgbds.gbdev.io/docs/%VITE_RGBDS_VERSION%" target="_blank">rgbds manual</a>
               </li>
               <li>
                 <a href="https://github.com/gbdev/rgbds-live/issues" target="_blank">Report a problem</a>

--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
             <ul>
               <li id="infomenu">Info...</li>
               <li>
+                <!-- This link is templated using the VITE_RGBDS_VERSION env variable, set at build time. See vite.config.js -->
                 <a href="https://rgbds.gbdev.io/docs/%VITE_RGBDS_VERSION%" target="_blank">rgbds manual</a>
               </li>
               <li>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,26 +1,33 @@
 import { defineConfig } from 'vite';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
+import { execSync } from 'node:child_process';
 
-export default defineConfig({
-  base: '/rgbds-live/',
-  build: {
-    target: ['chrome109', 'safari15.6', 'firefox102'],
-    outDir: 'www',
-    chunkSizeWarningLimit: 1000,
-  },
-  resolve: {
-    alias: {
-      ace: 'ace-builds/src-noconflict/',
+export default defineConfig(({ command, mode, isSsrBuild, isPreview }) => {
+  process.env.VITE_RGBDS_VERSION = execSync(
+    "git --git-dir=rgbds/.git -c safe.directory='*' describe --tags --always",
+  ).toString('utf8');
+  console.log("VITE_RGBDS_VERSION set to", process.env.VITE_RGBDS_VERSION)
+  return {
+    base: '/rgbds-live/',
+    build: {
+      target: ['chrome109', 'safari15.6', 'firefox102'],
+      outDir: 'www',
+      chunkSizeWarningLimit: 1000,
     },
-  },
-  plugins: [
-    viteStaticCopy({
-      targets: [
-        {
-          src: './node_modules/ace-builds/src-noconflict/**',
-          dest: 'assets/ace',
-        },
-      ],
-    }),
-  ],
+    resolve: {
+      alias: {
+        ace: 'ace-builds/src-noconflict/',
+      },
+    },
+    plugins: [
+      viteStaticCopy({
+        targets: [
+          {
+            src: './node_modules/ace-builds/src-noconflict/**',
+            dest: 'assets/ace',
+          },
+        ],
+      }),
+    ],
+  };
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,7 @@ import { viteStaticCopy } from 'vite-plugin-static-copy';
 import { execSync } from 'node:child_process';
 
 export default defineConfig(({ command, mode, isSsrBuild, isPreview }) => {
+  // Extract the RGBDS version we're using and set it as an env variable
   process.env.VITE_RGBDS_VERSION = execSync(
     "git --git-dir=rgbds/.git -c safe.directory='*' describe --tags --always",
   ).toString('utf8');


### PR DESCRIPTION
Closes #66 

For testing remeber to clear the changes(undo the patches) to binjgb and rgbds. 
You may use this commands from `rgbds-live` root directory:
```
cd rgbds && git clean -fd && git reset --hard && cd ../binjgb && git clean -fd && git reset --hard && cd ..
```
Then you are ready to execute `./build.sh`
In other case build may fail as build is trying to apply patches every time