### PR TITLE
Fix github action build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,30 +2,38 @@ name: CI
 on:
   push:
   pull_request:
+env:
+  EM_VERSION: 3.1.45
+  EM_CACHE_FOLDER: 'emsdk-cache'
 jobs:
   build:
     name: WASM Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Setup emscripten
-        uses: mymindstorm/setup-emsdk@v11
+      - name: Setup cache
+        uses: actions/cache@v4
         with:
-          version: 3.1.45
-          actions-cache-folder: emsdk-cache
+          path: ${{env.EM_CACHE_FOLDER}}
+          key: ${{env.EM_VERSION}}-${{ runner.os }}
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+      - name: Setup emscripten
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: ${{env.EM_VERSION}}
+          actions-cache-folder: ${{env.EM_CACHE_FOLDER}}
       - name: Build RGBDS
         run: ./build-rgbds.sh
         shell: bash
       - name: Build binjgb
         run: ./build-binjgb.sh
         shell: bash
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '20.x'
       - name: Install node dependencies
         run: npm ci
       - name: Build with Vite


### PR DESCRIPTION
Updating some actions should fix `Unable to reserve cache with key 3.1.45-x64-master, another job may be creating this cache.`

Closes #78