### PR TITLE
fixing binjgb build on newer emscripten versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
   push:
   pull_request:
 env:
-  EM_VERSION: 3.1.45
+  EM_VERSION: 4.0.8
   EM_CACHE_FOLDER: 'emsdk-cache'
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Try online at [gbdev.io/rgbds-live](https://gbdev.io/rgbds-live/).
 System requirements:
 
 - bison, cmake
-- [emscripten](https://emscripten.org/docs/getting_started/downloads.html)
+- [emscripten](https://emscripten.org/docs/getting_started/downloads.html) working with 4.0.8 (you can change version with `emsdk install 4.0.8 && emsdk activate 4.0.8`)
 
 Make sure you initialize submodules to be able to build the WebAssembly modules:
 

--- a/build-binjgb.sh
+++ b/build-binjgb.sh
@@ -11,7 +11,7 @@ cd binjgb
 
 ! mkdir out
 cd out
-cmake -E env LDFLAGS='-s EXPORT_ES6=1' \
+cmake -E env LDFLAGS='-s EXPORT_ES6=1 -s EXPORTED_RUNTIME_METHODS=['HEAP8']' \
     cmake \
         -DCMAKE_TOOLCHAIN_FILE=${EMSDK}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake \
         -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
adding used version to readme
update build to using this version

Closes #94 
[compiled test](https://selvin.pl/rgbds-live-4.0.8/)